### PR TITLE
Add ghsummon and copilot-setup-steps workflows

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,17 @@
+name: "Copilot Setup Steps"
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ghsummon.yml
+++ b/.github/workflows/ghsummon.yml
@@ -1,0 +1,42 @@
+name: ghsummon
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**.md"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  ghsummon:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@df432e13a1e41244a83daa3a073cc55d3858a4a0 # v2.0.6
+        with:
+          app-id: ${{ vars.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Setup Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version: stable
+
+      - name: Build and Run ghsummon
+        run: |
+          go build -o ghsummon ./cmd/ghsummon
+          ./ghsummon
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary

Set up GitHub Actions workflows for running ghsummon in this repository.

### New files

- **`.github/workflows/copilot-setup-steps.yml`** — Minimal Copilot Coding Agent setup workflow (required for Agent activation). Job name `copilot-setup-steps` is fixed by Copilot convention.
- **`.github/workflows/ghsummon.yml`** — Runs ghsummon on push to `main` when `.md` files change. Builds from source (tagpr pattern) instead of downloading release binary.

### Token setup

Uses `actions/create-github-app-token` for reliable Copilot triggering.

**Required repository settings:**
- `vars.APP_ID` — GitHub App ID
- `secrets.APP_PRIVATE_KEY` — GitHub App private key

The GitHub App needs these permissions: `contents: write`, `pull_requests: write`, `issues: write`.
