### PR TITLE
Add GraphQL-Features header for Copilot assignment

### DIFF
--- a/github.go
+++ b/github.go
@@ -219,6 +219,7 @@ func (g *ghClient) graphql(ctx context.Context, query string, variables map[stri
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("GraphQL-Features", "issues_copilot_assignment_api_support")
 
 	resp, err := g.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
## Problem

Copilot agent was not being assigned to PRs. The `suggestedActors` query returned no copilot agent, causing `copilot agent not found` error.

## Root Cause

The GitHub GraphQL API requires the custom header `GraphQL-Features: issues_copilot_assignment_api_support` for all Copilot-related assignment operations.

ref: https://github.blog/changelog/2025-12-03-assign-issues-to-copilot-using-the-api/

## Fix

Add the required header to the `graphql()` helper method. This affects both:
- `suggestedActors` query (finding the copilot agent ID)
- `addAssigneesToAssignable` mutation (assigning copilot to PR)

## Verified

Manually tested: `addAssigneesToAssignable` with the header successfully assigned Copilot to PR #10.
