### PR TITLE
Remove user lookup fallback for Copilot agent ID

### DIFF
--- a/github.go
+++ b/github.go
@@ -153,23 +153,9 @@ func (g *ghClient) assignCopilot(ctx context.Context, prNodeID string) error {
 	return nil
 }
 
-// getCopilotAgentID finds the Copilot agent's node ID.
-// First tries suggestedActors query, then falls back to direct user lookup.
+// getCopilotAgentID finds the Copilot agent's node ID via suggestedActors GraphQL query.
+// Requires a user token (PAT or user-to-server); App installation tokens cannot see copilot-swe-agent.
 func (g *ghClient) getCopilotAgentID(ctx context.Context) (string, error) {
-	// Try suggestedActors first (works with user tokens / PATs)
-	if id, err := g.getCopilotIDFromSuggestedActors(ctx); err == nil && id != "" {
-		return id, nil
-	}
-
-	// Fallback: look up copilot-swe-agent directly (works with App installation tokens)
-	if id, err := g.getCopilotIDFromUserLookup(ctx); err == nil && id != "" {
-		return id, nil
-	}
-
-	return "", fmt.Errorf("copilot agent not found; ensure Copilot Coding Agent is enabled for this repository")
-}
-
-func (g *ghClient) getCopilotIDFromSuggestedActors(ctx context.Context) (string, error) {
 	query := `query($owner: String!, $name: String!) {
 		repository(owner: $owner, name: $name) {
 			suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 100) {
@@ -203,47 +189,19 @@ func (g *ghClient) getCopilotIDFromSuggestedActors(ctx context.Context) (string,
 		} `json:"errors"`
 	}
 	if err := g.graphql(ctx, query, variables, &result); err != nil {
-		return "", err
+		return "", fmt.Errorf("failed to query suggested actors: %w", err)
 	}
 	if len(result.Errors) > 0 {
-		return "", fmt.Errorf("%s", result.Errors[0].Message)
+		return "", fmt.Errorf("GraphQL error querying actors: %s", result.Errors[0].Message)
 	}
 	for _, node := range result.Data.Repository.SuggestedActors.Nodes {
-		if node.Login == "copilot-swe-agent" || node.Login == "copilot" {
+		if node.Login == "copilot-swe-agent" {
 			if node.ID != "" {
 				return node.ID, nil
 			}
 		}
 	}
-	return "", fmt.Errorf("not found in suggested actors")
-}
-
-func (g *ghClient) getCopilotIDFromUserLookup(ctx context.Context) (string, error) {
-	query := `query($login: String!) {
-		user(login: $login) {
-			id
-		}
-	}`
-	variables := map[string]any{
-		"login": "copilot-swe-agent",
-	}
-	var result struct {
-		Data struct {
-			User struct {
-				ID string `json:"id"`
-			} `json:"user"`
-		} `json:"data"`
-		Errors []struct {
-			Message string `json:"message"`
-		} `json:"errors"`
-	}
-	if err := g.graphql(ctx, query, variables, &result); err != nil {
-		return "", err
-	}
-	if len(result.Errors) > 0 {
-		return "", fmt.Errorf("%s", result.Errors[0].Message)
-	}
-	return result.Data.User.ID, nil
+	return "", fmt.Errorf("copilot agent not found in suggested actors; ensure Copilot Coding Agent is enabled and a user token (PAT) is used")
 }
 
 // graphql executes a GraphQL query/mutation against the GitHub API.


### PR DESCRIPTION
## Background

The `getCopilotIDFromUserLookup` fallback was added to support GitHub App installation tokens which cannot see `copilot-swe-agent` via `suggestedActors`.

## Why remove

1. The `user(login:)` query returns a **User-type node ID**, while Copilot assignment requires the **Bot-type node ID** from `suggestedActors` — the fallback silently fails
2. Official docs require a **user token** (PAT or user-to-server) — App installation tokens are explicitly unsupported for Copilot assignment
3. Since we now require a PAT (`secrets.GHSUMMON_TOKEN`), `suggestedActors` always works and the fallback is dead code

ref: https://docs.github.com/en/copilot/how-tos/use-copilot-agents/coding-agent/create-a-pr#assigning-an-issue-to-copilot-via-the-github-api
