### PR TITLE
Fix token masking

### DIFF
--- a/diff.go
+++ b/diff.go
@@ -41,7 +41,9 @@ func detectShallowAndDeepen(ctx context.Context) error {
 func configureGitToken(ctx context.Context, token string) error {
 	// Encode as "x-access-token:<token>" in base64 for HTTP basic auth.
 	encoded := base64.StdEncoding.EncodeToString([]byte("x-access-token:" + token))
-	fmt.Printf("::add-mask::%s\n", encoded)
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		fmt.Printf("::add-mask::%s\n", encoded)
+	}
 	cmd := exec.CommandContext(ctx, "git", "config", "--local",
 		"http.https://github.com/.extraheader",
 		"AUTHORIZATION: basic "+encoded)

--- a/github.go
+++ b/github.go
@@ -54,7 +54,7 @@ func (g *ghClient) branchExists(ctx context.Context, branch string) (bool, error
 
 // createEmptyCommitAndBranch creates an empty commit on a new branch via Git Data API.
 func (g *ghClient) createEmptyCommitAndBranch(ctx context.Context, baseBranch, branch, message string) error {
-	// Get default branch HEAD ref
+	// Get base branch HEAD ref
 	defaultRef, _, err := g.client.Git.GetRef(ctx, g.owner, g.repo, "refs/heads/"+baseBranch)
 	if err != nil {
 		return fmt.Errorf("failed to get HEAD ref: %w", err)


### PR DESCRIPTION
## Fixes

### Token masking (diff.go)
`::add-mask::` is a GitHub Actions workflow command. Previously it was always printed to stdout, leaking the encoded token during local execution. Now only emitted when `GITHUB_ACTIONS=="true"` (documented default env var).
