### PR TITLE
Upgrade actions/checkout from v5 to v6

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ jobs:
   research:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: Songmu/ghsummon@v0
         with:
           token: ${{ secrets.GHSUMMON_TOKEN }}
@@ -106,7 +106,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 ```
 
 ### Action Inputs


### PR DESCRIPTION
It's a minor change, but I've updated actions/checkout from v5 to v6 in the README, as I believe there's no specific reason to stick with the older version 😃 

Note: I've verified that this works with `actions/checkout@v6`, just in case.
